### PR TITLE
Limit number of SeqRepo instances

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,10 @@ package_dir =
 zip_safe = True
 
 install_requires =
-    biocommons.seqrepo>=0.6.2
+    biocommons.seqrepo~=0.6
     coloredlogs
-    connexion[swagger-ui]>=2.2
+    connexion[swagger-ui]~=2.2
+    Flask~=2.2
 
 [options.extras_require]
 dev =

--- a/src/seqrepo_rest_service/threadglobals.py
+++ b/src/seqrepo_rest_service/threadglobals.py
@@ -3,24 +3,22 @@
 """
 
 import logging
-import os
 
 from biocommons.seqrepo import SeqRepo
-from flask import current_app, g
+from flask import current_app
 
 _logger = logging.getLogger(__name__)
 
 
 def get_seqrepo():
     seqrepo_dir = current_app.config["seqrepo_dir"]
-    _logger.info(f"Opening {seqrepo_dir=}")
     return _get_or_create("seqrepo", lambda: SeqRepo(root_dir=seqrepo_dir))
 
 
 def _get_or_create(k, f):
-    k = "_" + k
-    o = getattr(g, k, None)
+    k = '_' + k
+    o = getattr(_get_or_create, k, None)
     if o is None:
         o = f()
-        setattr(g, k, o)
+        setattr(_get_or_create, k, o)
     return o

--- a/src/seqrepo_rest_service/threadglobals.py
+++ b/src/seqrepo_rest_service/threadglobals.py
@@ -12,13 +12,15 @@ _logger = logging.getLogger(__name__)
 
 def get_seqrepo():
     seqrepo_dir = current_app.config["seqrepo_dir"]
+    if _get_or_create("seqrepo", None, False) is None:
+        _logger.info("Opening seqrepo_dir=%s", seqrepo_dir)
     return _get_or_create("seqrepo", lambda: SeqRepo(root_dir=seqrepo_dir))
 
 
-def _get_or_create(k, f):
-    k = '_' + k
+def _get_or_create(k, f, create=True):
+    k = "_" + k
     o = getattr(_get_or_create, k, None)
-    if o is None:
+    if o is None and create:
         o = f()
         setattr(_get_or_create, k, o)
     return o


### PR DESCRIPTION
This solves #12 which is caused by a SeqRepo object being constructed per-request. The SeqRepo class has an `@lru_cache` on the open file handles to fasta files, and these references go out of scope after the end of the current request but may not be garbage collected until later. So when a lot of requests are sent in quick succession, the number of open file handles increases drastically and appears to potentially continue to sit in memory indefinitely depending on other memory allocation activity in the process.

Flask does not use any async when run through the current CLI setup in `cli.py` using connexion's `app.run` method. If run through something else that supports async then mutual exclusion around file handles in SeqRepo needs to be addressed either in this codebase or by applying changes in SeqRepo, as in https://github.com/biocommons/biocommons.seqrepo/pull/117