### PR TITLE
BIO-737 - Fork seqrepo rest service and make it production ready

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "biocommons.seqrepo ~= 0.6",
+    "biocommons.seqrepo ~= 0.6",    
     "coloredlogs",
     "connexion[swagger-ui] ~= 2.2",
     "Flask ~= 2.2",
+    "waitress"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
When the seqrepo-rest-service starts it gives a warning:

``WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.``

See BIO-737 for more detail on what this means. The short version is that when seqrepo-rest-service launches it is using a web server that is only meant to be used during development. For production we need to wrap it in a robust server. 

There are several options for which web server to use. I've chosen waitress because it is supposed to be best for applications that do a lot of IO (as opposed to high cpu), and i think that describes seqrepo. 


