### PR TITLE
BIO-764 - Enable cache and use rotating log for SeqRepo REST service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ devready:
 
 #=> venv: make a Python 3 virtual environment
 ${VE_DIR}:
-	python3 -mvenv $@; \
+	python -mvenv $@; \
 	source $@/bin/activate; \
-	python3 -m ensurepip --upgrade; \
+	python -m ensurepip --upgrade; \
 	pip install --upgrade pip setuptools wheel
 
 #=> develop: install package in develop mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "biocommons.seqrepo ~= 0.6",
+    "biocommons.seqrepo ~= 0.6",    
     "coloredlogs",
     "connexion[swagger-ui] ~= 2.2",
     "Flask ~= 2.2",
+    "waitress"
 ]
 
 [project.optional-dependencies]

--- a/src/seqrepo_rest_service/cli.py
+++ b/src/seqrepo_rest_service/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import importlib.resources
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 import pathlib
 import time
@@ -38,10 +39,14 @@ def _parse_opts():
     opts = ap.parse_args()
     return opts
 
-
-def main():
-    coloredlogs.install(level="INFO")
-
+def main():    
+    handler = RotatingFileHandler('seqrepo_rest_service.log', maxBytes=1000000, backupCount=1)    
+    formatter = logging.Formatter("%(asctime)s : %(levelname)s : [%(filename)s:%(lineno)s - %(funcName)s()] : %(message)s", "%Y-%m-%d %H:%M")
+    handler.setFormatter(formatter)    
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    root_logger.addHandler(handler)   
+    
     if "SEQREPO_DIR" in os.environ:
         _logger.warn("SEQREPO_DIR environment variable is now ignored")
 

--- a/src/seqrepo_rest_service/cli.py
+++ b/src/seqrepo_rest_service/cli.py
@@ -58,6 +58,7 @@ def main():
     cxapp = connexion.App(__name__, debug=False)
     cxapp.app.url_map.strict_slashes = False
     cxapp.app.config["seqrepo_dir"] = seqrepo_dir
+    cxapp.app.config["log_request_last_log_time"] = 0
 
     spec_files = []
 

--- a/src/seqrepo_rest_service/seqrepo/routes/sequence.py
+++ b/src/seqrepo_rest_service/seqrepo/routes/sequence.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 
 from connexion import NoContent, request
 
@@ -14,9 +15,10 @@ def get(alias, start=None, end=None):
         if start > end:
             return problem(422, "Invalid coordinates: start > end")
     
-    log_request(alias, start, end)
+    start_time_real = time.perf_counter()
+    start_time_user = time.process_time()
     
-    sr = get_seqrepo() 
+    sr = get_seqrepo()
     
     seq_ids = get_sequence_ids(sr, alias)
     if not seq_ids:
@@ -24,4 +26,11 @@ def get(alias, start=None, end=None):
     if len(seq_ids) > 1:
         return problem(422, f"Multiple sequences exist for alias '{alias}'")
     seq_id = seq_ids[0]
-    return sr.sequences.fetch(seq_id, start, end), 200
+    f = sr.sequences.fetch(seq_id, start, end), 200
+
+    stop_time_real = time.perf_counter()
+    stop_time_user = time.process_time()
+
+    log_request(alias, start, end, stop_time_real - start_time_real, stop_time_user - start_time_user)
+        
+    return f

--- a/src/seqrepo_rest_service/seqrepo/routes/sequence.py
+++ b/src/seqrepo_rest_service/seqrepo/routes/sequence.py
@@ -31,6 +31,6 @@ def get(alias, start=None, end=None):
     stop_time_real = time.perf_counter()
     stop_time_user = time.process_time()
 
-    log_request(alias, start, end, stop_time_real - start_time_real, stop_time_user - start_time_user)
+    log_request(alias, start, end, stop_time_real - start_time_real, stop_time_user - start_time_user, sr)
         
     return f

--- a/src/seqrepo_rest_service/seqrepo/routes/sequence.py
+++ b/src/seqrepo_rest_service/seqrepo/routes/sequence.py
@@ -3,7 +3,7 @@ import re
 
 from connexion import NoContent, request
 
-from ...threadglobals import get_seqrepo
+from ...threadglobals import get_seqrepo, log_request
 from ...utils import get_sequence_ids, problem
 
 _logger = logging.getLogger(__name__)
@@ -13,7 +13,11 @@ def get(alias, start=None, end=None):
     if start is not None and end is not None:
         if start > end:
             return problem(422, "Invalid coordinates: start > end")
-    sr = get_seqrepo()
+    
+    log_request(alias, start, end)
+    
+    sr = get_seqrepo() 
+    
     seq_ids = get_sequence_ids(sr, alias)
     if not seq_ids:
         return NoContent, 404

--- a/src/seqrepo_rest_service/threadglobals.py
+++ b/src/seqrepo_rest_service/threadglobals.py
@@ -32,14 +32,14 @@ def _convert_time(real_seconds, user_seconds):
     dt_user = datetime.timedelta(seconds = user_seconds)    
     return str(dt_real), str(dt_user)
 
-def log_request(alias, start, end, time_real, time_user):
+def log_request(alias, start, end, time_real, time_user, sr):
     """
     We are seeing cpu spikes from the REST service even when we don't think there are any requests coming in. 
     This method will log requests so we can see if indeed there are requests associated with the increased cpu.  
     To prevent excessive logging log messages are limited to once every 30s.
     """
     # Minimum number of seconds between log messages
-    log_request_interval = 30
+    log_request_interval = 60
     
     log_request_last_log_time = current_app.config["log_request_last_log_time"]
     number_of_seconds_since_last_query = time.time() - log_request_last_log_time
@@ -48,9 +48,13 @@ def log_request(alias, start, end, time_real, time_user):
         http_client_ip = request.remote_addr
         
         real_time, user_time = _convert_time(time_real, time_user)
-        
-        _logger.info(f"seqrepo rest request: {alias}, {start}, {end}, {http_client_ip}, {real_time}, {user_time}")
-        
+
+        if hasattr(sr.sequences._open_for_reading, "cache_info"):
+            cache_results = sr.sequences._open_for_reading.cache_info()
+        else:
+            cache_results = 'no fd cache'
+
+        _logger.info(f"seqrepo rest request: {alias}, {start}, {end}, {http_client_ip}, {real_time}, {user_time}, {cache_results}")
+
         # This does not need to be threadsafe 
         current_app.config["log_request_last_log_time"] = time.time()
-    

--- a/src/seqrepo_rest_service/threadglobals.py
+++ b/src/seqrepo_rest_service/threadglobals.py
@@ -41,7 +41,7 @@ def log_request(alias, start, end):
 
     if number_of_seconds_since_last_query >= log_request_interval:
         _logger.info(f"seqrepo rest request: alias={alias}, start={start}, end={end}, http_client_ip={http_client_ip}")
-            
-    # This does not need to be threadsafe 
-    current_app.config["log_request_last_log_time"] = time.time()
+        
+        # This does not need to be threadsafe 
+        current_app.config["log_request_last_log_time"] = time.time()
     

--- a/src/seqrepo_rest_service/threadglobals.py
+++ b/src/seqrepo_rest_service/threadglobals.py
@@ -1,8 +1,10 @@
 """per-thread globals for seqrepo REST APIs"""
 
 import logging
+import time
 
 from biocommons.seqrepo import SeqRepo
+from connexion import request
 from flask import current_app
 
 _logger = logging.getLogger(__name__)
@@ -22,3 +24,24 @@ def _get_or_create(k, f, create=True):
         o = f()
         setattr(_get_or_create, k, o)
     return o
+
+def log_request(alias, start, end):
+    """
+    We are seeing cpu spikes from the REST service even when we don't think there are any requests coming in. 
+    This method will log requests so we can see if indeed there are requests associated with the increased cpu.  
+    To prevent excessive logging log messages are limited to once every 30s.
+    """
+    # Minimum number of seconds between log messages
+    log_request_interval = 30
+    
+    http_client_ip = request.remote_addr
+    
+    log_request_last_log_time = current_app.config["log_request_last_log_time"]
+    number_of_seconds_since_last_query = time.time() - log_request_last_log_time
+
+    if number_of_seconds_since_last_query >= log_request_interval:
+        _logger.info(f"seqrepo rest request: alias={alias}, start={start}, end={end}, http_client_ip={http_client_ip}")
+            
+    # This does not need to be threadsafe 
+    current_app.config["log_request_last_log_time"] = time.time()
+    

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+source venv/bin/activate
+export SEQREPO_FD_CACHE_MAXSIZE=10
+nohup seqrepo-rest-service /data/seqrepo/2024-02-20/ 2>&1 &


### PR DESCRIPTION
Three changes. See BIO-764 for details
- Created launch script that sets cache before starting seqrepo rest service. 
- Added log message that shows us the last time a query was received.
- Send logging to file rather than stdout